### PR TITLE
recurse on directories

### DIFF
--- a/report.bash
+++ b/report.bash
@@ -45,11 +45,21 @@ cmd_report() {
 
    [ ! -d "$PREFIX/.git" ] && _die "Your password store does not use .git, can't show report"
 
-   [ -z "$file" ] && _cmd_report_all_passwords || _cmd_report_password ${file%/}
+   if [ -z "$file" ]; then
+      _cmd_report_all_passwords
+   else
+      if [ -d "${PREFIX}/${file}" ]; then
+         _cmd_report_all_passwords "$file"
+      else
+         _cmd_report_password ${file%/}
+      fi
+   fi
 }
 
 _cmd_report_all_passwords() {
-   git -C "$PREFIX" ls-tree -r --name-only HEAD | grep -E "\.gpg$" | while read filename ; do
+   pass_prefix="$1"
+
+   git -C "$PREFIX" ls-tree -r --name-only HEAD | grep "^${pass_prefix}" | grep -E "\.gpg$" | while read filename ; do
       _cmd_report_password "$filename"
    done
 }


### PR DESCRIPTION
If a directory name is given as an argument, we currently get an error
saying "file not found".

Also the only way to recurse on a set of passwords is currently to
report on all passwords.

It would be nice to be able to report only on a subset of the repository
tree. For this, if a directory name is passed in as an argument, we
should recurse over all ".gpg"-ending files contained within this
directory.